### PR TITLE
Author as contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "realtime",
     "jupyter"
   ],
-  "author": "Kyle Kelley <rgbkrk@gmail.com>",
+  "author": "contributors",
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/jdfreder/single-cell-rtcollab/issues"


### PR DESCRIPTION
We can switch this to the jupyter email we've been including in other packages once we know this can be incorporated as a Jupyter project.

Follow up to #1 
